### PR TITLE
Fix incorrect import path casing in NavMenu.tsx

### DIFF
--- a/src/components/Header/NavMenu.tsx
+++ b/src/components/Header/NavMenu.tsx
@@ -1,4 +1,4 @@
-import styles from "../../styles/components/header/NavMenu.module.scss";
+import styles from "../../styles/components/Header/NavMenu.module.scss";
 import {NavLink} from "react-router-dom";
 
 interface NavMenuProps {


### PR DESCRIPTION
Corrects the import path casing for the NavMenu styles file to match the correct "Header" directory. This resolves potential issues on case-sensitive file systems.