### PR TITLE
Update loci information for specific disease data

### DIFF
--- a/src/assets/Diseases.ts
+++ b/src/assets/Diseases.ts
@@ -88,7 +88,7 @@ These are some of the empirical questions raised by the interesting proposal of 
             alt_names: [
                 'Familial defective apolipoprotein B-100',
             ],
-            locus: ['LDLR'],
+            locus: ['LDLR', 'ApoB', 'PCSK9'],
             mondo: ['https://monarchinitiative.org/MONDO:0005439', 'monarchinitiative.org/MONDO:0005439'],
         },
         text_data: {


### PR DESCRIPTION
Added 'ApoB' and 'PCSK9' to the locus array to provide a more comprehensive representation of associated genetic markers. This improves the accuracy and detail of the disease dataset.